### PR TITLE
feat :   게시물 신고하기, 댓글 신고하기 ,감정글 상세 조회에 닉네임 표시 기능 추가

### DIFF
--- a/src/main/java/com/example/emotrak/Service/CommentService.java
+++ b/src/main/java/com/example/emotrak/Service/CommentService.java
@@ -1,17 +1,18 @@
 package com.example.emotrak.Service;
 
 import com.example.emotrak.dto.CommentRequestDto;
-import com.example.emotrak.entity.Comment;
-import com.example.emotrak.entity.Daily;
-import com.example.emotrak.entity.User;
-import com.example.emotrak.entity.UserRoleEnum;
+import com.example.emotrak.dto.ReportRequestDto;
+import com.example.emotrak.entity.*;
 import com.example.emotrak.exception.CustomErrorCode;
 import com.example.emotrak.exception.CustomException;
 import com.example.emotrak.repository.BoardRepository;
 import com.example.emotrak.repository.CommentRepository;
+import com.example.emotrak.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static com.example.emotrak.entity.UserRoleEnum.ADMIN;
 
@@ -21,6 +22,7 @@ import static com.example.emotrak.entity.UserRoleEnum.ADMIN;
 public class CommentService {
     private final CommentRepository commentRepository;
     private final BoardRepository boardRepository;
+    private final ReportRepository reportRepository;
 
     //댓글작성
     public void createComment(Long id, CommentRequestDto commentRequestDto, User user) {
@@ -55,4 +57,25 @@ public class CommentService {
             throw new CustomException(CustomErrorCode.NOT_AUTHOR);
         }
     }
+
+    //댓글 신고하기
+    public void createReport(ReportRequestDto reportRequestDto, User user, Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new CustomException(CustomErrorCode.COMMENT_NOT_FOUND)
+        );
+        Optional<Report> existingReport = reportRepository.findByUserAndCommentId(user, commentId);
+        if (existingReport.isPresent()) {
+            throw new CustomException(CustomErrorCode.DUPLICATE_REPORT); // 이미 신고한 게시물입니다.
+        }
+        Report report = new Report(reportRequestDto, user, comment);
+        reportRepository.save(report);
+    }
+
+    // 댓글 신고 삭제하기
+    public void deleteReport(User user, Long commentId) {
+        Report report = reportRepository.findByUserAndCommentId(user, commentId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.REPORT_NOT_FOUND));
+        reportRepository.delete(report);
+    }
+
 }

--- a/src/main/java/com/example/emotrak/Service/DailyService.java
+++ b/src/main/java/com/example/emotrak/Service/DailyService.java
@@ -9,7 +9,6 @@ import com.example.emotrak.repository.DailyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 

--- a/src/main/java/com/example/emotrak/controller/BoardController.java
+++ b/src/main/java/com/example/emotrak/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.example.emotrak.controller;
 import com.example.emotrak.Service.BoardService;
 import com.example.emotrak.dto.BoardDetailResponseDto;
 import com.example.emotrak.dto.BoardRequestDto;
+import com.example.emotrak.dto.ReportRequestDto;
 import com.example.emotrak.exception.ResponseMessage;
 import com.example.emotrak.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -67,4 +68,22 @@ public class BoardController {
         BoardDetailResponseDto boardDetailResponseDto = boardService.getBoardDetail(boardId, userDetails.getUser(), page);
         return ResponseMessage.successResponse(HttpStatus.OK, "상세 조회 성공", boardDetailResponseDto);
     }
+
+    //게시물 신고하기
+    @PostMapping(value = "/boards/report/{boardId}")
+    public ResponseEntity<?> reportBoard(@PathVariable Long boardId,
+                                         @RequestBody @Valid ReportRequestDto reportRequestDto,
+                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 게시글 신고 처리
+        boardService.createReport(reportRequestDto, userDetails.getUser(), boardId);
+        return ResponseMessage.successResponse(HttpStatus.CREATED, "게시글 신고 성공", null);
+    }
+
+    //게시물 신고 삭제하기
+    @DeleteMapping("/boards/report/{boardId}")
+    public ResponseEntity<?> deleteReport(@PathVariable Long boardId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        boardService.deleteReport(userDetails.getUser(), boardId);
+        return ResponseMessage.successResponse(HttpStatus.OK, "게시물 신고 삭제 성공", null);
+    }
+
 }

--- a/src/main/java/com/example/emotrak/controller/CommentController.java
+++ b/src/main/java/com/example/emotrak/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.example.emotrak.controller;
 
 import com.example.emotrak.Service.CommentService;
 import com.example.emotrak.dto.CommentRequestDto;
+import com.example.emotrak.dto.ReportRequestDto;
 import com.example.emotrak.exception.ResponseMessage;
 import com.example.emotrak.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,4 +45,24 @@ public class CommentController {
         commentService.deleteComment(commentId, userDetails.getUser());
         return ResponseMessage.successResponse(HttpStatus.OK, "댓글 삭제 성공", null);
     }
+
+    //댓글 신고하기
+    @PostMapping("/comments/report/{commentId}")
+    public ResponseEntity<?> reportBoard(@PathVariable Long commentId,
+                                         @RequestBody ReportRequestDto reportRequestDto,
+                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 게시글 신고 처리
+        commentService.createReport(reportRequestDto, userDetails.getUser(), commentId);
+        return ResponseMessage.successResponse(HttpStatus.CREATED, "게시글 신고 성공", null);
+    }
+
+    //댓글 신고 삭제하기
+    @DeleteMapping("/comments/report/{commentId}")
+    public ResponseEntity<?> deleteReport(@PathVariable Long commentId,
+                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.deleteReport(userDetails.getUser(), commentId);
+        return ResponseMessage.successResponse(HttpStatus.OK, "게시물 신고 삭제 성공", null);
+    }
+
+
 }

--- a/src/main/java/com/example/emotrak/dto/BoardDetailResponseDto.java
+++ b/src/main/java/com/example/emotrak/dto/BoardDetailResponseDto.java
@@ -21,6 +21,7 @@ public class BoardDetailResponseDto {
     private String detail;
     private String imgUrl;
     private boolean hasAuth;
+    private String nickname;
     private List<CommentDetailResponseDto> commentDetailResponseDtoList;
 
     private String formatCreatedAt(LocalDateTime createdAt) {
@@ -43,6 +44,7 @@ public class BoardDetailResponseDto {
         this.imgUrl = daily.getImgUrl();
         this.hasAuth = daily.getUser().equals(user) || user.hasAdmin();
         this.commentDetailResponseDtoList = commentDetailResponseDtoList;
+        this.nickname = user.getNickname();
 
     }
 }

--- a/src/main/java/com/example/emotrak/dto/CommentDetailResponseDto.java
+++ b/src/main/java/com/example/emotrak/dto/CommentDetailResponseDto.java
@@ -18,6 +18,7 @@ public class CommentDetailResponseDto {
     private String comment;
     private String createdAt;
     private boolean hasAuth;
+    private String nickname;
 
     private String formatCreatedAt(LocalDateTime createdAt) {
        return createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
@@ -29,5 +30,6 @@ public class CommentDetailResponseDto {
         this.comment = comment.getComment();
         this.createdAt = formatCreatedAt(comment.getCreatedAt());
         this.hasAuth = comment.getUser().equals(user) || user.hasAdmin();
+        this.nickname = user.getNickname();
     }
 }

--- a/src/main/java/com/example/emotrak/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/emotrak/dto/ReportRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.emotrak.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReportRequestDto {
+
+//    @NotBlank(message = "신고 사유를 입력해주세요.")
+    private String reason;
+
+}

--- a/src/main/java/com/example/emotrak/entity/Report.java
+++ b/src/main/java/com/example/emotrak/entity/Report.java
@@ -1,0 +1,45 @@
+package com.example.emotrak.entity;
+
+import com.example.emotrak.dto.ReportRequestDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Report extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String reason;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "dailyId")
+    private Daily daily;
+
+    @ManyToOne
+    @JoinColumn(name = "commentId")
+    private Comment comment;
+
+
+    public Report(ReportRequestDto reportRequestDto, User user, Daily daily) {
+        this.reason = reportRequestDto.getReason();
+        this.user = user;
+        this.daily = daily;
+    }
+
+    public Report(ReportRequestDto reportRequestDto, User user, Comment comment) {
+        this.reason = reportRequestDto.getReason();
+        this.user = user;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/example/emotrak/exception/CustomErrorCode.java
+++ b/src/main/java/com/example/emotrak/exception/CustomErrorCode.java
@@ -38,11 +38,13 @@ public enum CustomErrorCode {
     BOARD_NOT_FOUND(NOT_FOUND, "x-1001", "선택한 게시물을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(NOT_FOUND, "x-1002", "선택한 댓글을 찾을 수 없습니다."),
     CONTENT_NOT_FOUND(NOT_FOUND, "x-1003", "찾을 수 없는 유형입니다."),
+    REPORT_NOT_FOUND(NOT_FOUND,"x-1004","신고내역을 찾을 수 없습니다"),
 
 
     /* 409 CONFLICT : 중복 */
     DUPLICATE_EMAIL(CONFLICT, "x-1001", "중복된 이메일이 존재합니다"),
-    DUPLICATE_NICKNAME(CONFLICT, "x-1002", "중복된 닉네임이 존재합니다");
+    DUPLICATE_NICKNAME(CONFLICT, "x-1002", "중복된 닉네임이 존재합니다"),
+    DUPLICATE_REPORT(CONFLICT,"x-1003" ,"이미 신고한 게시물입니다" );
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/example/emotrak/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotrak/repository/ReportRepository.java
@@ -1,0 +1,14 @@
+package com.example.emotrak.repository;
+
+import com.example.emotrak.entity.Report;
+import com.example.emotrak.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    // 사용자와 게시물 ID로 신고 정보를 찾는 메서드
+    Optional<Report> findByUserAndDailyId(User user, Long dailyId);
+
+    Optional<Report> findByUserAndCommentId(User user, Long commentId);
+
+}


### PR DESCRIPTION
작업 내용:

게시물 및 댓글 신고 기능을 추가하였습니다
추가적으로 삭제기능을 넣어놓았습니다 (DB과적문제로 프론트와 논의 필요)

공유게시판 상세페이지
boarddetailResponseDto.java commentdetailResponseDto.java
에 nickname 을 추가하였습니다


 CustomErrorCode.java에
  REPORT_NOT_FOUND(NOT_FOUND,"x-1004","신고내역을 찾을 수 없습니다"),
  DUPLICATE_REPORT(CONFLICT,"x-1003" ,"이미 신고한 게시물입니다" );

변경된 파일:

BoardController.java , commentcontroller.java
BoardService.java, commentservice.java 
Report.java ReportRepository.java
boarddetailResponseDto.java commentdetailResponseDto.java


customerrorcode.java



테스트 완료 : 로컬환경에서 작성된 api 형식대로  테스트 완료 및 빌드 완료 했습니다. 